### PR TITLE
Remove redundant if branch in ensure_hash method

### DIFF
--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -15,17 +15,13 @@ class GraphqlController < ApplicationController
 
   # Handle form data, JSON body, or a blank value
   def ensure_hash(ambiguous_param)
+    return {} if ambiguous_param.blank?
+
     case ambiguous_param
     when String
-      if ambiguous_param.present?
-        ensure_hash(JSON.parse(ambiguous_param))
-      else
-        {}
-      end
+      ensure_hash(JSON.parse(ambiguous_param))
     when Hash, ActionController::Parameters
       ambiguous_param
-    when nil
-      {}
     else
       raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
     end


### PR DESCRIPTION
This removes a redundant branch and improves readability IMO.